### PR TITLE
Update documentation

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.422-librca

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=8.0.422-librca

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The steps below require Docker to be installed on your machine.
 4. Run the Docker container `docker run --rm -p 8080:8080 nes-struts1-test-app`
 5. Open the browser and navigate to `http://localhost:8080/struts-cookbook-1.3.10/`
 
+# Next Steps
+
+When you are ready to upgrade to the fully supported version of the HeroDevs Never Ending Support for Struts 1.3, please reach out to us at [HeroDevs](https://www.herodevs.com/).
+You will need to modify the `settings.xml` or `gradle.properties` to include your credentials.
+After that, check out the `nes` branch in this repository for the specific version changes.
+
 # Additional Information
 
 HeroDevs offers Never Ending Support for a [number of products](https://www.herodevs.com/support).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
-# nes-struts1-test-app
+# HeroDevs Struts 1.3 Sample Application
 
-## Struts 1 Test App - Sourced from [Struts 1 Cookbook](https://github.com/apache/struts1/tree/trunk/apps/cookbook)
+Welcome to the sample application for [HeroDevs](https://www.herodevs.com/) Never Ending Support for Struts 1.3.
+
+This sample application is sourced from the [Struts 1 Cookbook](https://github.com/apache/struts1/tree/trunk/apps/cookbook).
+Instructions how to build and run the application are provided below.
+
+## HeroDevs Configuration
+
+### Trial Versions
+
+This sample application is using the **trial** version of the HeroDevs Never Ending Support for Struts 1.3.
+The trial version provides **no security fixes**.
+Instead, it is a version of the latest open source code available before we patched out the security vulnerabilities.
+The intent of a trial version is so you can verify connectivity with the HeroDevs repository and be ready to easily drop in the fully supported, paid versions.
+
+### Build Changes
+
+To connect to the HeroDevs repository, two steps were taken:
+
+- Configure Registry (add a `settings.xml` for Maven or a `gradle.properties` for Gradle)
+- Update Build Configuration (add dependencies and repositories in a `pom.xml` or `build.gradle`)
+
+You can see these changes are already made in the main branch of this repository.
+
+## Build and Run
+
+The steps below require Docker to be installed on your machine.
 
 ### Setup
+
 1. Clone the repo
 2. build the project `./mvnw clean package`
 3. build the Docker image `docker build -t nes-struts1-test-app .`
 4. Run the Docker container `docker run --rm -p 8080:8080 nes-struts1-test-app`
 5. Open the browser and navigate to `http://localhost:8080/struts-cookbook-1.3.10/`
+
+# Additional Information
+
+HeroDevs offers Never Ending Support for a [number of products](https://www.herodevs.com/support).
+We would love to partner with you to provide support for your legacy applications.
+We are always expanding our offerings, so if you don't see what you need, please reach out to us.
+More technical documentation can be found on our [docs website](https://docs.herodevs.com/).

--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,37 @@
         </resources>
     </build>
 
+    <!-- Add the HeroDevs NES Repository -->
+    <repositories>
+        <repository>
+            <id>herodevs-nes-registry</id>
+            <url>https://registry.nes.herodevs.com/maven</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>herodevs-nes-registry</id>
+            <url>https://registry.nes.herodevs.com/maven</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
+        <!-- HeroDevs Drop In Replacement for Struts 1.3 -->
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts-core</artifactId>
-            <version>1.3.10</version>
+            <!-- HeroDevs version -->
+            <version>1.3.10-struts-1.3.11-trial</version>
         </dependency>
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts-taglib</artifactId>
-            <version>1.3.10</version>
+            <!-- HeroDevs version -->
+            <version>1.3.10-struts-1.3.11-trial</version>
         </dependency>
+        <!-- End HeroDevs Drop In Replacement for Struts 1.3 -->
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+        <server>
+            <id>herodevs-nes-registry</id>
+            <username>some@email.com</username>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
Added information in the README about HeroDevs product offerings. Also provided context about what the trial versions are and are not. Changed maven build files to use the trial version of HeroDevs NES by default in the main branch.